### PR TITLE
fix(lint):lint対応

### DIFF
--- a/app/pokemon_stats_judge/entity/pokemon.py
+++ b/app/pokemon_stats_judge/entity/pokemon.py
@@ -1,3 +1,4 @@
+"""Entity of Pokemon"""
 import dataclasses
 import os
 import math
@@ -40,7 +41,7 @@ class Pokemon:
         """型チェック、スキーマチェックを実行する。
         """
         pokemon_dict = vars(self)
-        for arg_name, expected_arg_type in self.__annotations__.items():
+        for arg_name, expected_arg_type in self.__annotations__.items(): # pylint: disable=no-member
             # 種族値、個体値、努力値は型がNoneの場合でもTrueを返す。
             # Todo: もっと賢い方法に修正する。 # pylint: disable=fixme
             if arg_name in ('pokemon_base_stats', 'pokemon_ivs', 'pokemon_evs'):

--- a/app/pokemon_stats_judge/entity/pokemon_base_stats.py
+++ b/app/pokemon_stats_judge/entity/pokemon_base_stats.py
@@ -25,7 +25,7 @@ class PokemonBaseStats:
         return dataclasses.asdict(self)
 
     def is_valid(self) -> None:
-        """ポケモンの能力値のみのdictを返す。
+        """型チェック、スキーマチェックを実行する。
         """
         evs_dict = self.get_dict()
         for arg_name, expected_arg_type in self.__annotations__.items(): # pylint: disable=no-member

--- a/app/pokemon_stats_judge/entity/pokemon_base_stats.py
+++ b/app/pokemon_stats_judge/entity/pokemon_base_stats.py
@@ -1,9 +1,12 @@
+"""Entity of PokemonBaseStats"""
 import dataclasses
 from pokemon_stats_judge.entity.Exception.pokemon_exception import InvalidArgumentTypeException
 
 
 @dataclasses.dataclass(frozen=True)
 class PokemonBaseStats:
+    """ポケモンの種族値
+    """
     hp: int
     phys_atk: int
     phys_def: int
@@ -12,13 +15,23 @@ class PokemonBaseStats:
     speed: int
 
     def __post_init__(self) -> None:
+        """初期化時に型チェックとスキーマチェックのためにis_valid()を実行する。
+        """
         self.is_valid()
 
     def get_dict(self) -> dict:
+        """自身をdict型に変換したものを返す。
+        """
         return dataclasses.asdict(self)
 
     def is_valid(self) -> None:
+        """ポケモンの能力値のみのdictを返す。
+        """
         evs_dict = self.get_dict()
-        for arg_name, expected_arg_type in self.__annotations__.items():
+        for arg_name, expected_arg_type in self.__annotations__.items(): # pylint: disable=no-member
             if not isinstance(evs_dict[arg_name], expected_arg_type):
-                raise InvalidArgumentTypeException(arg_name, type(evs_dict[arg_name]), expected_arg_type)
+                raise InvalidArgumentTypeException(
+                    arg_name,
+                    type(evs_dict[arg_name]),
+                    expected_arg_type
+                )

--- a/app/pokemon_stats_judge/entity/pokemon_evs.py
+++ b/app/pokemon_stats_judge/entity/pokemon_evs.py
@@ -1,3 +1,4 @@
+"""Entity of EffortValues"""
 import dataclasses
 from pokemon_stats_judge.entity.Exception.pokemon_exception import InvalidArgumentTypeException
 from pokemon_stats_judge.entity.Exception.pokemon_exception import InvalidEffortValueException
@@ -6,6 +7,8 @@ from pokemon_stats_judge.entity.Exception.pokemon_exception import InvalidEffort
 
 @dataclasses.dataclass(frozen=True)
 class PokemonEffortValues:
+    """ポケモンの努力値
+    """
     hp: int
     phys_atk: int
     phys_def: int
@@ -14,16 +17,26 @@ class PokemonEffortValues:
     speed: int
 
     def __post_init__(self) -> None:
+        """初期化時に型チェックとスキーマチェックのためにis_valid()を実行する。
+        """
         self.is_valid()
 
     def get_dict(self) -> dict:
+        """自身をdict型に変換したものを返す。
+        """
         return dataclasses.asdict(self)
 
     def is_valid(self) -> None:
+        """型チェック、スキーマチェックを実行する。
+        """
         evs_dict = self.get_dict()
-        for arg_name, expected_arg_type in self.__annotations__.items():
+        for arg_name, expected_arg_type in self.__annotations__.items(): # pylint: disable=no-member
             if not isinstance(evs_dict[arg_name], expected_arg_type):
-                raise InvalidArgumentTypeException(arg_name, type(evs_dict[arg_name]), expected_arg_type)
+                raise InvalidArgumentTypeException(
+                    arg_name,
+                    type(evs_dict[arg_name]),
+                    expected_arg_type
+                )
         for stat, effort_value in evs_dict.items():
             self._ev_check(stat, effort_value)
         self._ev_sum_check(evs_dict)

--- a/app/pokemon_stats_judge/entity/pokemon_ivs.py
+++ b/app/pokemon_stats_judge/entity/pokemon_ivs.py
@@ -1,3 +1,4 @@
+"""Entity of IndividualValues"""
 import dataclasses
 from typing import List
 from pokemon_stats_judge.entity.Exception.pokemon_exception import InvalidArgumentTypeException
@@ -6,6 +7,8 @@ from pokemon_stats_judge.entity.Exception.pokemon_exception import InvalidIndivi
 
 @dataclasses.dataclass(frozen=True)
 class PokemonIndividualValues:
+    """ポケモンの個体値
+    """
     hp: List[int]
     phys_atk: List[int]
     phys_def: List[int]
@@ -14,17 +17,27 @@ class PokemonIndividualValues:
     speed: List[int]
 
     def __post_init__(self) -> None:
+        """初期化時に型チェックとスキーマチェックのためにis_valid()を実行する。
+        """
         self.is_valid()
 
     def get_dict(self) -> dict:
+        """自身をdict型に変換したものを返す。
+        """
         return dataclasses.asdict(self)
 
     def is_valid(self) -> None:
+        """型チェック、スキーマチェックを実行する。
+        """
         ivs_dict = self.get_dict()
-        for arg_name, expected_arg_type in self.__annotations__.items():
-            # Todo: 型チェックを動的になるよう修正
+        for arg_name, expected_arg_type in self.__annotations__.items(): # pylint: disable=no-member,unused-variable
+            # Todo: 型チェックを動的になるよう修正 # pylint: disable=fixme
             if not isinstance(ivs_dict[arg_name], list):
-                raise InvalidArgumentTypeException(arg_name, type(ivs_dict[arg_name]), list)
+                raise InvalidArgumentTypeException(
+                    arg_name,
+                    type(ivs_dict[arg_name]),
+                    list
+                )
         for stat, individual_list in ivs_dict.items():
             self._iv_check(stat, individual_list)
 

--- a/app/pokemon_stats_judge/test/entity/conftest.py
+++ b/app/pokemon_stats_judge/test/entity/conftest.py
@@ -1,8 +1,11 @@
+"""ポケモン用のテストデータ"""
 import pytest
 
 
 @pytest.fixture(autouse=True, scope='class')
 def test_base_stats():
+    """種族値のテストデータ
+    """
     hinoyakoma_base_stats = {
         'hp': 62,
         'phys_atk': 73,
@@ -15,6 +18,8 @@ def test_base_stats():
 
 @pytest.fixture(autouse=True, scope='class')
 def test_pokemon_stats():
+    """実値のテストデータ
+    """
     hinoyakoma_stats = {
         'pokemon_name': 'ヒノヤコマ',
         'pokemon_level': 100,
@@ -30,6 +35,8 @@ def test_pokemon_stats():
 
 @pytest.fixture(autouse=True, scope='class')
 def test_ivs():
+    """個体値のテストデータ
+    """
     hinoyakoma_ivs = {
         "hp": [23],
         "phys_atk": [19],
@@ -42,6 +49,8 @@ def test_ivs():
 
 @pytest.fixture(autouse=True, scope='class')
 def test_evs():
+    """努力値のテストデータ
+    """
     hinoyakoma_evs = {
         "hp": 252,
         "phys_atk": 0,

--- a/app/pokemon_stats_judge/test/entity/test_pokemon.py
+++ b/app/pokemon_stats_judge/test/entity/test_pokemon.py
@@ -1,52 +1,50 @@
+"""Test PokemonEntity"""
 import pytest
-import unittest
 from pokemon_stats_judge.entity.pokemon import Pokemon
 from pokemon_stats_judge.entity.pokemon import PokemonBaseStats
-from pokemon_stats_judge.entity.pokemon import PokemonEffortValues
-from pokemon_stats_judge.entity.pokemon import PokemonIndividualValues
 from pokemon_stats_judge.entity.Exception.pokemon_exception import InvalidArgumentTypeException
 
 
-class TestPokemon(object):
-    """test class of pokemon entity
+class TestPokemon:
+    """ポケモンエンティティのテスト用クラス
     """
 
-    def test_create_pokemon(self, test_pokemon_stats, test_base_stats):
-        """test pokemon entity create
+    def test_create_pokemon(self, test_pokemon_stats):
+        """種族値個体値努力値を入れずに作成できるかのテスト
         """
 
         test_pokemon = Pokemon(
-                                test_pokemon_stats['pokemon_name'],
-                                test_pokemon_stats['pokemon_level'],
-                                test_pokemon_stats['pokemon_nature'],
-                                test_pokemon_stats['pokemon_stat_hp'],
-                                test_pokemon_stats['pokemon_stat_phys_atk'],
-                                test_pokemon_stats['pokemon_stat_phys_def'],
-                                test_pokemon_stats['pokemon_stat_spcl_atk'],
-                                test_pokemon_stats['pokemon_stat_spcl_def'],
-                                test_pokemon_stats['pokemon_stat_speed'],
-        ) 
+            test_pokemon_stats['pokemon_name'],
+            test_pokemon_stats['pokemon_level'],
+            test_pokemon_stats['pokemon_nature'],
+            test_pokemon_stats['pokemon_stat_hp'],
+            test_pokemon_stats['pokemon_stat_phys_atk'],
+            test_pokemon_stats['pokemon_stat_phys_def'],
+            test_pokemon_stats['pokemon_stat_spcl_atk'],
+            test_pokemon_stats['pokemon_stat_spcl_def'],
+            test_pokemon_stats['pokemon_stat_speed']
+        )
         assert test_pokemon.pokemon_name == test_pokemon_stats['pokemon_name']
 
-    def test_get_dict(self, test_pokemon_stats, test_base_stats):
+    def test_get_dict(self, test_pokemon_stats):
         """get_dictメソッドでdict型を返すかテストする。
         """
 
         test_pokemon = Pokemon(
-                                test_pokemon_stats['pokemon_name'],
-                                test_pokemon_stats['pokemon_level'],
-                                test_pokemon_stats['pokemon_nature'],
-                                test_pokemon_stats['pokemon_stat_hp'],
-                                test_pokemon_stats['pokemon_stat_phys_atk'],
-                                test_pokemon_stats['pokemon_stat_phys_def'],
-                                test_pokemon_stats['pokemon_stat_spcl_atk'],
-                                test_pokemon_stats['pokemon_stat_spcl_def'],
-                                test_pokemon_stats['pokemon_stat_speed'],
-        ) 
-        test_pokemon_dict = test_pokemon.get_dict() 
+            test_pokemon_stats['pokemon_name'],
+            test_pokemon_stats['pokemon_level'],
+            test_pokemon_stats['pokemon_nature'],
+            test_pokemon_stats['pokemon_stat_hp'],
+            test_pokemon_stats['pokemon_stat_phys_atk'],
+            test_pokemon_stats['pokemon_stat_phys_def'],
+            test_pokemon_stats['pokemon_stat_spcl_atk'],
+            test_pokemon_stats['pokemon_stat_spcl_def'],
+            test_pokemon_stats['pokemon_stat_speed']
+        )
+        test_pokemon_dict = test_pokemon.get_dict()
         assert isinstance(test_pokemon_dict, dict)
 
-    def test_is_valid(self, test_pokemon_stats, test_base_stats, test_evs, test_ivs):
+    def test_is_valid(self, test_pokemon_stats, test_base_stats):
         """個体値、努力値の場所に種族値を入れて"InvalidArgumentTypeException"を返すか確認する。
         """
         pokemon_base_stats = PokemonBaseStats(
@@ -58,22 +56,22 @@ class TestPokemon(object):
             test_base_stats['speed']
         )
         with pytest.raises(InvalidArgumentTypeException):
-            test_pokemon = Pokemon(
-                                    test_pokemon_stats['pokemon_name'],
-                                    test_pokemon_stats['pokemon_level'],
-                                    test_pokemon_stats['pokemon_nature'],
-                                    test_pokemon_stats['pokemon_stat_hp'],
-                                    test_pokemon_stats['pokemon_stat_phys_atk'],
-                                    test_pokemon_stats['pokemon_stat_phys_def'],
-                                    test_pokemon_stats['pokemon_stat_spcl_atk'],
-                                    test_pokemon_stats['pokemon_stat_spcl_def'],
-                                    test_pokemon_stats['pokemon_stat_speed'],
-                                    pokemon_base_stats,
-                                    pokemon_base_stats,
-                                    pokemon_base_stats
-            ) 
+            Pokemon(
+                test_pokemon_stats['pokemon_name'],
+                test_pokemon_stats['pokemon_level'],
+                test_pokemon_stats['pokemon_nature'],
+                test_pokemon_stats['pokemon_stat_hp'],
+                test_pokemon_stats['pokemon_stat_phys_atk'],
+                test_pokemon_stats['pokemon_stat_phys_def'],
+                test_pokemon_stats['pokemon_stat_spcl_atk'],
+                test_pokemon_stats['pokemon_stat_spcl_def'],
+                test_pokemon_stats['pokemon_stat_speed'],
+                pokemon_base_stats,
+                pokemon_base_stats,
+                pokemon_base_stats
+            )
 
-    def test_get_pokemon_by_replaced_base_stats(self, test_pokemon_stats, test_base_stats, test_evs, test_ivs):
+    def test_get_pokemon_by_replaced_base_stats(self, test_pokemon_stats, test_base_stats):
         """get_pokemon_by_replaced_base_statsで種族値を置き換えられるか確認する。
         """
         pokemon_base_stats = PokemonBaseStats(
@@ -86,20 +84,20 @@ class TestPokemon(object):
         )
 
         test_pokemon = Pokemon(
-                                test_pokemon_stats['pokemon_name'],
-                                test_pokemon_stats['pokemon_level'],
-                                test_pokemon_stats['pokemon_nature'],
-                                test_pokemon_stats['pokemon_stat_hp'],
-                                test_pokemon_stats['pokemon_stat_phys_atk'],
-                                test_pokemon_stats['pokemon_stat_phys_def'],
-                                test_pokemon_stats['pokemon_stat_spcl_atk'],
-                                test_pokemon_stats['pokemon_stat_spcl_def'],
-                                test_pokemon_stats['pokemon_stat_speed'],
-        ) 
+            test_pokemon_stats['pokemon_name'],
+            test_pokemon_stats['pokemon_level'],
+            test_pokemon_stats['pokemon_nature'],
+            test_pokemon_stats['pokemon_stat_hp'],
+            test_pokemon_stats['pokemon_stat_phys_atk'],
+            test_pokemon_stats['pokemon_stat_phys_def'],
+            test_pokemon_stats['pokemon_stat_spcl_atk'],
+            test_pokemon_stats['pokemon_stat_spcl_def'],
+            test_pokemon_stats['pokemon_stat_speed']
+        )
         test_pokemon = test_pokemon.get_pokemon_by_replaced_base_stats(pokemon_base_stats)
         assert test_pokemon.pokemon_base_stats.hp == test_base_stats['hp']
 
-    def test_get_pokemon_by_estimated_ivs_and_evs(self, test_pokemon_stats, test_base_stats, test_evs, test_ivs):
+    def test_get_pokemon_by_estimated_ivs_and_evs(self, test_pokemon_stats, test_base_stats):
         """get_pokemon_by_estimated_ivs_and_evsによって個体値と努力値を推測できているか確認する。
         """
         pokemon_base_stats = PokemonBaseStats(
@@ -111,20 +109,20 @@ class TestPokemon(object):
             test_base_stats['speed']
         )
         test_pokemon = Pokemon(
-                                test_pokemon_stats['pokemon_name'],
-                                test_pokemon_stats['pokemon_level'],
-                                test_pokemon_stats['pokemon_nature'],
-                                test_pokemon_stats['pokemon_stat_hp'],
-                                test_pokemon_stats['pokemon_stat_phys_atk'],
-                                test_pokemon_stats['pokemon_stat_phys_def'],
-                                test_pokemon_stats['pokemon_stat_spcl_atk'],
-                                test_pokemon_stats['pokemon_stat_spcl_def'],
-                                test_pokemon_stats['pokemon_stat_speed']
-        ) 
+            test_pokemon_stats['pokemon_name'],
+            test_pokemon_stats['pokemon_level'],
+            test_pokemon_stats['pokemon_nature'],
+            test_pokemon_stats['pokemon_stat_hp'],
+            test_pokemon_stats['pokemon_stat_phys_atk'],
+            test_pokemon_stats['pokemon_stat_phys_def'],
+            test_pokemon_stats['pokemon_stat_spcl_atk'],
+            test_pokemon_stats['pokemon_stat_spcl_def'],
+            test_pokemon_stats['pokemon_stat_speed']
+        )
         test_pokemon = test_pokemon.get_pokemon_by_replaced_base_stats(pokemon_base_stats)
         test_pokemon = test_pokemon.get_pokemon_by_estimated_ivs_and_evs()
         assert test_pokemon.pokemon_ivs.hp == [31]
-        assert test_pokemon.pokemon_ivs.phys_def == [5,6]
+        assert test_pokemon.pokemon_ivs.phys_def == [5, 6]
         assert test_pokemon.pokemon_evs.hp == 220
         assert test_pokemon.pokemon_evs.phys_def == 0
         assert test_pokemon.pokemon_evs.speed == 228
@@ -135,7 +133,7 @@ class TestPokemon(object):
         nature_change_dict = Pokemon._get_nature_change_dict('ひかえめ')
         assert nature_change_dict['spcl_atk'] == 1.1
 
-    def test_estimate_stat_ivs(self, test_pokemon_stats, test_base_stats, test_evs, test_ivs):
+    def test_estimate_stat_ivs(self, test_pokemon_stats, test_base_stats, test_ivs):
         """_estimate_stat_ivsによっていくつかの能力値の個体値を推測できるか確認する。
         """
         estimate_ivs_hp = Pokemon._estimate_stat_ivs(
@@ -181,7 +179,7 @@ class TestPokemon(object):
             nature_change=1.0,
             pokemon_stat=test_pokemon_stats['pokemon_stat_spcl_def'],
             base_stat=test_base_stats['spcl_def'],
-            ivs_int=test_ivs['spcl_def'][0], 
+            ivs_int=test_ivs['spcl_def'][0],
             estimate_hp=False
         )
         assert estimate_evs_spcl_def == test_evs['spcl_def']

--- a/app/pokemon_stats_judge/test/entity/test_pokemon_base_stats.py
+++ b/app/pokemon_stats_judge/test/entity/test_pokemon_base_stats.py
@@ -1,12 +1,15 @@
+"""Test BaseStats"""
 import pytest
-import unittest
-from pokemon_stats_judge.entity.pokemon import Pokemon
 from pokemon_stats_judge.entity.pokemon import PokemonBaseStats
 from pokemon_stats_judge.entity.Exception.pokemon_exception import InvalidArgumentTypeException
 
 
-class TestPokemonBaseStats(object):
+class TestPokemonBaseStats:
+    """種族値のテスト用クラス
+    """
     def test_create_base_stats(self, test_base_stats):
+        """正しい値を入れて作成できるか確認する。
+        """
         base_stats = PokemonBaseStats(
             test_base_stats['hp'],
             test_base_stats['phys_atk'],
@@ -18,6 +21,8 @@ class TestPokemonBaseStats(object):
         assert base_stats.hp == 62
 
     def test_get_dict(self, test_base_stats):
+        """get_dictメソッドでdict型を返すかテストする。
+        """
         base_stats = PokemonBaseStats(
             test_base_stats['hp'],
             test_base_stats['phys_atk'],
@@ -30,8 +35,10 @@ class TestPokemonBaseStats(object):
         assert isinstance(base_stats_dict, dict)
 
     def test_is_valid(self, test_base_stats):
+        """hpに入るはずのないlist型を渡して"InvalidArgumentTypeException"が出るか確認する。
+        """
         with pytest.raises(InvalidArgumentTypeException):
-            base_stats = PokemonBaseStats(
+            PokemonBaseStats(
                 [100],
                 test_base_stats['phys_atk'],
                 test_base_stats['phys_def'],

--- a/app/pokemon_stats_judge/test/entity/test_pokemon_evs.py
+++ b/app/pokemon_stats_judge/test/entity/test_pokemon_evs.py
@@ -1,16 +1,17 @@
-import unittest
+"""Test EffortValues"""
 import pytest
-from pokemon_stats_judge.entity.pokemon import Pokemon
-from pokemon_stats_judge.entity.pokemon import PokemonBaseStats
 from pokemon_stats_judge.entity.pokemon import PokemonEffortValues
-from pokemon_stats_judge.entity.pokemon import PokemonIndividualValues
 from pokemon_stats_judge.entity.Exception.pokemon_exception import InvalidArgumentTypeException
 from pokemon_stats_judge.entity.Exception.pokemon_exception import InvalidEffortValueException
 from pokemon_stats_judge.entity.Exception.pokemon_exception import InvalidEffortValuesException
 
 
-class TestPokemonEffortValues(object):
+class TestPokemonEffortValues:
+    """努力値のテスト用クラス
+    """
     def test_create_evs(self, test_evs):
+        """正しい値を入れて作成できるか確認する。
+        """
         evs = PokemonEffortValues(
             hp=test_evs['hp'],
             phys_atk=test_evs['phys_atk'],
@@ -19,9 +20,11 @@ class TestPokemonEffortValues(object):
             spcl_def=test_evs['spcl_def'],
             speed=test_evs['speed']
         )
-        assert evs.hp is 252
+        assert evs.hp == 252
 
     def test_get_dict(self, test_evs):
+        """get_dictメソッドでdict型を返すかテストする。
+        """
         evs = PokemonEffortValues(
             hp=test_evs['hp'],
             phys_atk=test_evs['phys_atk'],
@@ -33,7 +36,9 @@ class TestPokemonEffortValues(object):
         evs_dict = evs.get_dict()
         assert isinstance(evs_dict, dict)
 
-    def test_is_valid(self, test_evs):
+    def test_is_valid(self):
+        """素早さに入るはずのないlist型を渡して"InvalidArgumentTypeException"が出るか確認する。
+        """
         with pytest.raises(InvalidArgumentTypeException):
             PokemonEffortValues(
                 hp=252,
@@ -44,17 +49,21 @@ class TestPokemonEffortValues(object):
                 speed=[252]
             )
 
-    def test_schema_evs_value(self, test_evs):
+    def test_schema_evs_value(self):
+        """努力値の最大値255を超えた値を入れるとエラーが出るか確認する。
+        """
         with pytest.raises(InvalidEffortValueException):
             PokemonEffortValues(
                 hp=300,
-                phys_atk=test_evs['phys_atk'],
-                phys_def=test_evs['phys_def'],
-                spcl_atk=test_evs['spcl_atk'],
-                spcl_def=test_evs['spcl_def'],
-                speed=test_evs['speed']
+                phys_atk=0,
+                phys_def=0,
+                spcl_atk=0,
+                spcl_def=0,
+                speed=0
             )
-    def test_schema_evs_values(self, test_evs):
+    def test_schema_evs_values(self):
+        """努力値の合計が510を超えていないか確認する。
+        """
         with pytest.raises(InvalidEffortValuesException):
             PokemonEffortValues(
                 hp=252,

--- a/app/pokemon_stats_judge/test/entity/test_pokemon_ivs.py
+++ b/app/pokemon_stats_judge/test/entity/test_pokemon_ivs.py
@@ -1,4 +1,4 @@
-import unittest
+"""Test IndividualValues"""
 import pytest
 from pokemon_stats_judge.entity.pokemon import Pokemon
 from pokemon_stats_judge.entity.pokemon import PokemonBaseStats
@@ -7,8 +7,12 @@ from pokemon_stats_judge.entity.Exception.pokemon_exception import InvalidArgume
 from pokemon_stats_judge.entity.Exception.pokemon_exception import InvalidIndividualValueException
 
 
-class TestPokemonIndividualValues(object):
+class TestPokemonIndividualValues:
+    """個体値のテスト用クラス
+    """
     def test_create_ivs(self, test_ivs):
+        """正しい値を入れて作成できるか確認する。
+        """
         ivs = PokemonIndividualValues(
             hp=test_ivs['hp'],
             phys_atk=test_ivs['phys_atk'],
@@ -20,6 +24,8 @@ class TestPokemonIndividualValues(object):
         assert ivs.hp[0] is 23
 
     def test_get_dict(self, test_ivs):
+        """get_dictメソッドでdict型を返すかテストする。
+        """
         ivs = PokemonIndividualValues(
             hp=test_ivs['hp'],
             phys_atk=test_ivs['phys_atk'],
@@ -32,6 +38,8 @@ class TestPokemonIndividualValues(object):
         assert isinstance(ivs_dict, dict)
 
     def test_is_valid(self, test_ivs):
+        """入るはずのないlist型を渡して"InvalidArgumentTypeException"が出るか確認する。
+        """
         with pytest.raises(InvalidArgumentTypeException):
             PokemonIndividualValues(
                 hp=[7,8],
@@ -43,6 +51,8 @@ class TestPokemonIndividualValues(object):
             )
 
     def test_schema_ivs_value(self, test_ivs):
+        """個体値の最大の31を超えた数字を入れた場合、"InvalidIndividualValueException"が出るか確認する。
+        """
         with pytest.raises(InvalidIndividualValueException):
             PokemonIndividualValues(
                 hp=[7,8],

--- a/app/pokemon_stats_judge/test/entity/test_pokemon_ivs.py
+++ b/app/pokemon_stats_judge/test/entity/test_pokemon_ivs.py
@@ -1,7 +1,5 @@
 """Test IndividualValues"""
 import pytest
-from pokemon_stats_judge.entity.pokemon import Pokemon
-from pokemon_stats_judge.entity.pokemon import PokemonBaseStats
 from pokemon_stats_judge.entity.pokemon import PokemonIndividualValues
 from pokemon_stats_judge.entity.Exception.pokemon_exception import InvalidArgumentTypeException
 from pokemon_stats_judge.entity.Exception.pokemon_exception import InvalidIndividualValueException
@@ -21,7 +19,7 @@ class TestPokemonIndividualValues:
             spcl_def=test_ivs['spcl_def'],
             speed=test_ivs['speed']
         )
-        assert ivs.hp[0] is 23
+        assert ivs.hp[0] == 23
 
     def test_get_dict(self, test_ivs):
         """get_dictメソッドでdict型を返すかテストする。
@@ -37,28 +35,28 @@ class TestPokemonIndividualValues:
         ivs_dict = ivs.get_dict()
         assert isinstance(ivs_dict, dict)
 
-    def test_is_valid(self, test_ivs):
+    def test_is_valid(self):
         """入るはずのないlist型を渡して"InvalidArgumentTypeException"が出るか確認する。
         """
         with pytest.raises(InvalidArgumentTypeException):
             PokemonIndividualValues(
-                hp=[7,8],
-                phys_atk=[7,8],
-                phys_def=[7,8],
-                spcl_atk=[7,8],
-                spcl_def=[7,8],
-                speed=39
+                hp=[7, 8],
+                phys_atk=[7, 8],
+                phys_def=[7, 8],
+                spcl_atk=[7, 8],
+                spcl_def=[7, 8],
+                speed=31
             )
 
-    def test_schema_ivs_value(self, test_ivs):
+    def test_schema_ivs_value(self):
         """個体値の最大の31を超えた数字を入れた場合、"InvalidIndividualValueException"が出るか確認する。
         """
         with pytest.raises(InvalidIndividualValueException):
             PokemonIndividualValues(
-                hp=[7,8],
-                phys_atk=[7,8],
-                phys_def=[7,8],
-                spcl_atk=[7,8],
-                spcl_def=[7,8],
+                hp=[7, 8],
+                phys_atk=[7, 8],
+                phys_def=[7, 8],
+                spcl_atk=[7, 8],
+                spcl_def=[7, 8],
                 speed=[39]
             )


### PR DESCRIPTION
Close #7 

## 修正内容
 - lint対応

## ルール排除理由
| Code | 内容 | 理由 |
| ---- | ---- | ---- |
| R0801 | Similar lines in %s files | ポケモンの能力値の部分はどうしても似通ってしまうため |
| C0301 | Line too long (%s/%s) | 計算式を複数行にすると逆に可読性が落ちたため | 
| R0913 | Too many arguments (%s/%s) | 計算に複数の引数が必要で、分けると可読性が落ちるため |
| R0201 | Method could be a function| Test関数は自動で呼ばれるため |
| W0212 | Access to a protected member %s of a client class | Testで呼び出しているため

## 実行結果
```python
> pylint -d R0801,C0301,R0913,R0201,W0212 .\app\pokemon_stats_judge      

-------------------------------------------------------------------
Your code has been rated at 10.00/10 (previous run: 9.46/10, +0.54)
```